### PR TITLE
Change styling of the homepage, fix CodeExample bug

### DIFF
--- a/components/CodeExample/index.tsx
+++ b/components/CodeExample/index.tsx
@@ -7,17 +7,18 @@ type Props = {}
 // TODO: The same like with Markdown here we may want to rename this
 function CodeExample({ codeStructure }: Props) {
     const codeExamples = codeExamplesFactory(codeStructure);
+    // console.log("🚀 ~ file: index.tsx:10 ~ CodeExample ~ codeExamples", codeExamples)
     // TODO: This is dummy sync function for testing purposes we have to change it the way example will be rendered with mounting of component
-    console.log("🚀 0 codeExamples", codeExamples)
 
     useEffect(() => {
         if(codeExamples) {
+            console.log("🚀 ~ file: index.tsx:15 ~ useEffect ~ codeExamples", codeExamples)
             setCodeExample(codeExamples['javascript'])
         }
     }, [codeExamples])
 
     const [language, changeLanguage] = useState('javascript');
-    const [codeExample, setCodeExample] = useState(null);
+    const [codeExample, setCodeExample] = useState(codeExamples['javascript']);
     const [areLineNumbersVisible, toggleLineNumbersVisibility] = useState(true);
     console.log("🚀 1 language", language)
     console.log("🚀 2 codeExample", codeExample)

--- a/components/StackNavbar/index.tsx
+++ b/components/StackNavbar/index.tsx
@@ -5,10 +5,10 @@ import { stackNavSettings, buildUrl } from './settings';
 
 const NavElement = ({ url, title, active }) => {
     if (!url) {
-        return (<Navbar.Text>{title}</Navbar.Text>)
+        return (<ul> <Navbar.Text className="text-dark">{title}</Navbar.Text> </ul>)
     }
 
-    return <Nav.Link className={active ? 'link-active' : ''} href={buildUrl(url)}>{title}</Nav.Link>
+    return <li> <Nav.Link className={active ? 'link-active' : ''} href={buildUrl(url)}>{title}</Nav.Link> </li>
 }
 
 

--- a/data-structures/LinkedList/codeExamples.ts
+++ b/data-structures/LinkedList/codeExamples.ts
@@ -1,6 +1,10 @@
 
 export default {
-    javascript: 'linked list test',
+    javascript: `linked list test
+    class Node {
+
+    }
+    `,
     python: `
     linked list
     python

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -19,7 +19,7 @@ const Layout = ({ Component, pageProps }) => {
 export default function App({ Component, pageProps }: AppProps) {
   return (<Container fluid className="p-0 main-wrapper">
     <HeaderNavbar />
-    <div className='content bg-black'>
+    <div className='content'>
       <StackNavbar />
       <main>
         <Layout Component={Component} pageProps={pageProps} />

--- a/pages/data-structures/[dataStructure]/code-examples.tsx
+++ b/pages/data-structures/[dataStructure]/code-examples.tsx
@@ -8,9 +8,8 @@ const DataStructuresCodeExamplesPage = () => {
   const { dataStructure } = router.query;
   return (
     <section>
-
       <h3>{dataStructure} Code Examples</h3>
-      <CodeExample dataStructure={dataStructure}/>
+      <CodeExample codeStructure={dataStructure}/>
     </section>
   );
 };

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -81,7 +81,7 @@
 }
 
 .center::before {
-  background: var(--secondary-glow);
+  /* background: var(--secondary-glow); */
   border-radius: 50%;
   width: 480px;
   height: 360px;
@@ -132,7 +132,7 @@
 
 /* Conic Gradient Animation */
 .thirteen::before {
-  animation: 6s rotate linear infinite;
+  /* animation: 6s rotate linear infinite; */
   width: 200%;
   height: 200%;
   background: var(--tile-border);
@@ -143,11 +143,11 @@
   inset: 0;
   padding: 1px;
   border-radius: var(--border-radius);
-  background: linear-gradient(
+  /* background: linear-gradient(
     to bottom right,
     rgba(var(--tile-start-rgb), 1),
     rgba(var(--tile-end-rgb), 1)
-  );
+  ); */
   background-clip: content-box;
 }
 
@@ -226,11 +226,11 @@
     border-radius: 0;
     border: none;
     border-bottom: 1px solid rgba(var(--callout-border-rgb), 0.25);
-    background: linear-gradient(
+    /* background: linear-gradient(
       to bottom,
       rgba(var(--background-start-rgb), 1),
       rgba(var(--callout-rgb), 0.5)
-    );
+    ); */
     background-clip: padding-box;
     backdrop-filter: blur(24px);
   }
@@ -241,11 +241,11 @@
     inset: auto 0 0;
     padding: 2rem;
     height: 200px;
-    background: linear-gradient(
+    /* background: linear-gradient(
       to bottom,
       transparent 0%,
       rgb(var(--background-end-rgb)) 40%
-    );
+    ); */
     z-index: 1;
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -87,12 +87,6 @@ body {
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
 }
 
 a {


### PR DESCRIPTION
Fixed bug related to displaying code example options (programming languages select)
Changed styling of the homepage:
- changed background to white
<img width="1273" alt="image" src="https://user-images.githubusercontent.com/25038744/216790804-093ae491-9157-48ab-b9ca-c2513a6dcbfb.png">
